### PR TITLE
Change org.jenkins-ci.plugins:plugin version to 1.424 to support Java 7.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.417</version><!-- which version of Jenkins is this plugin built against? -->
+    <version>1.424</version><!-- which version of Jenkins is this plugin built against? -->
   </parent>
 
   <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Plugin can't be built with Java 7.

Error message:

[INFO] --- maven-hpi-plugin:1.67:apt-compile (default-apt-compile) @ all-changes ---
Oct 26, 2013 1:04:58 PM org.sonatype.guice.bean.reflect.Logs$JULSink warn
WARNING: Error injecting: org.jenkinsci.maven.plugins.hpi.AptCompiler
java.lang.NoClassDefFoundError: com/sun/mirror/apt/AnnotationProcessorFactory
	at java.lang.Class.getDeclaredConstructors0(Native Method)
	at java.lang.Class.privateGetDeclaredConstructors(Class.java:2413)
	at java.lang.Class.getDeclaredConstructors(Class.java:1855)
	at com.google.inject.spi.InjectionPoint.forConstructorOf(InjectionPoint.java:245)
	at com.google.inject.internal.ConstructorBindingImpl.create(ConstructorBindingImpl.java:98)
	at com.google.inject.internal.InjectorImpl.createUninitializedBinding(InjectorImpl.java:654)
	at com.google.inject.internal.InjectorImpl.createJustInTimeBinding(InjectorImpl.java:856)
	at com.google.inject.internal.InjectorImpl.createJustInTimeBindingRecursive(InjectorImpl.java:783)
	at com.google.inject.internal.InjectorImpl.getJustInTimeBinding(InjectorImpl.java:279)
	at com.google.inject.internal.InjectorImpl.getBindingOrThrow(InjectorImpl.java:211)
	at com.google.inject.internal.InjectorImpl.getProviderOrThrow(InjectorImpl.java:979)
	at com.google.inject.internal.InjectorImpl.getProvider(InjectorImpl.java:1012)
	at com.google.inject.internal.InjectorImpl.getProvider(InjectorImpl.java:975)
	at com.google.inject.internal.InjectorImpl.getInstance(InjectorImpl.java:1025)
	at org.sonatype.guice.bean.reflect.AbstractDeferredClass.get(AbstractDeferredClass.java:45)
	at com.google.inject.internal.ProviderInternalFactory.provision(ProviderInternalFactory.java:84)
	at com.google.inject.internal.InternalFactoryToInitializableAdapter.provision(InternalFactoryToInitializableAdapter.java:52)
	at com.google.inject.internal.ProviderInternalFactory$1.call(ProviderInternalFactory.java:70)
	at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:100)
	at org.sonatype.guice.plexus.lifecycles.PlexusLifecycleManager.onProvision(PlexusLifecycleManager.java:138)
	at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:108)
	at com.google.inject.internal.ProvisionListenerStackCallback.provision(ProvisionListenerStackCallback.java:55)
	at com.google.inject.internal.ProviderInternalFactory.circularGet(ProviderInternalFactory.java:68)
	at com.google.inject.internal.InternalFactoryToInitializableAdapter.get(InternalFactoryToInitializableAdapter.java:45)
	at com.google.inject.internal.ProviderToInternalFactoryAdapter$1.call(ProviderToInternalFactoryAdapter.java:46)
	at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1043)
	at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40)
	at com.google.inject.Scopes$1$1.get(Scopes.java:59)
	at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:41)
	at com.google.inject.internal.InjectorImpl$3$1.call(InjectorImpl.java:990)
	at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1036)
	at com.google.inject.internal.InjectorImpl$3.get(InjectorImpl.java:986)
	at org.sonatype.guice.bean.locators.LazyBeanEntry.getValue(LazyBeanEntry.java:83)
	at org.sonatype.guice.plexus.locators.LazyPlexusBean.getValue(LazyPlexusBean.java:49)
	at java.util.AbstractMap.get(AbstractMap.java:182)
	at org.codehaus.plexus.compiler.manager.DefaultCompilerManager.getCompiler(DefaultCompilerManager.java:54)
	at org.jenkinsci.maven.plugins.hpi.AbstractCompilerMojo.execute(AbstractCompilerMojo.java:260)
	at org.jenkinsci.maven.plugins.hpi.CompilerMojo.execute(CompilerMojo.java:111)
	at org.jenkinsci.maven.plugins.hpi.AptMojo.execute(AptMojo.java:24)
	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:101)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:209)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:84)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:59)
	at org.apache.maven.lifecycle.internal.LifecycleStarter.singleThreadedBuild(LifecycleStarter.java:183)
	at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:161)
	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:320)
	at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:156)
	at org.apache.maven.cli.MavenCli.execute(MavenCli.java:537)
	at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:196)
	at org.apache.maven.cli.MavenCli.main(MavenCli.java:141)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:601)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:290)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:230)
	at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:409)
	at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:352)
Caused by: java.lang.ClassNotFoundException: com.sun.mirror.apt.AnnotationProcessorFactory
	at org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy.loadClass(SelfFirstStrategy.java:50)
	at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClass(ClassRealm.java:244)
	at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClass(ClassRealm.java:230)
	... 60 more
